### PR TITLE
Automated Changelog Entry for 0.1.0a0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,32 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a0
+
+([Full Changelog](https://github.com/QuantStack/jupyterlab-blockly/compare/first-commit...7621d106ba51831512b803f07f1dd70b48b41a79))
+
+### Enhancements made
+
+- code execution implementation [#15](https://github.com/QuantStack/jupyterlab-blockly/pull/15) ([@DenisaCG](https://github.com/DenisaCG))
+- added personalized JupyterLab theme [#11](https://github.com/QuantStack/jupyterlab-blockly/pull/11) ([@DenisaCG](https://github.com/DenisaCG))
+- Manager [#10](https://github.com/QuantStack/jupyterlab-blockly/pull/10) ([@hbcarlos](https://github.com/hbcarlos))
+- DocumentWidget & Toolbox [#7](https://github.com/QuantStack/jupyterlab-blockly/pull/7) ([@DenisaCG](https://github.com/DenisaCG))
+
+### Bugs fixed
+
+- Fix Build workflow [#14](https://github.com/QuantStack/jupyterlab-blockly/pull/14) ([@hbcarlos](https://github.com/hbcarlos))
+- Fix build badge link [#13](https://github.com/QuantStack/jupyterlab-blockly/pull/13) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Maintenance and upkeep improvements
+
+- Fix Build workflow [#14](https://github.com/QuantStack/jupyterlab-blockly/pull/14) ([@hbcarlos](https://github.com/hbcarlos))
+- Fix build badge link [#13](https://github.com/QuantStack/jupyterlab-blockly/pull/13) ([@hbcarlos](https://github.com/hbcarlos))
+- delete empty file [#12](https://github.com/QuantStack/jupyterlab-blockly/pull/12) ([@DenisaCG](https://github.com/DenisaCG))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-blockly/graphs/contributors?from=2022-01-10&to=2022-04-11&type=c))
+
+[@DenisaCG](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-blockly+involves%3ADenisaCG+updated%3A2022-01-10..2022-04-11&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-blockly+involves%3Ahbcarlos+updated%3A2022-01-10..2022-04-11&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a0 on main
```
Python version: 0.1.0a0
npm version: jupyterlab-blockly: 0.1.0-alpha.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | QuantStack/jupyterlab-blockly  |
| Branch  | main  |
| Version Spec | 0.1.0-alpha.0 |
| Since | first-commit |