### PR TITLE
Automated Changelog Entry for 0.1.0a1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a1
+
+([Full Changelog](https://github.com/QuantStack/jupyterlab-blockly/compare/v0.1.0a0...76fe431fa9e8c24ce81d917969882b74ac671fce))
+
+### Enhancements made
+
+- added Blockly to launcher [#21](https://github.com/QuantStack/jupyterlab-blockly/pull/21) ([@DenisaCG](https://github.com/DenisaCG))
+- FileType, Manager and Register [#20](https://github.com/QuantStack/jupyterlab-blockly/pull/20) ([@hbcarlos](https://github.com/hbcarlos))
+- initial code for changing the language [#18](https://github.com/QuantStack/jupyterlab-blockly/pull/18) ([@DenisaCG](https://github.com/DenisaCG))
+
+### Maintenance and upkeep improvements
+
+- FileType, Manager and Register [#20](https://github.com/QuantStack/jupyterlab-blockly/pull/20) ([@hbcarlos](https://github.com/hbcarlos))
+- add patch for jupyterlab-codeeditor to be compatible with latest type… [#17](https://github.com/QuantStack/jupyterlab-blockly/pull/17) ([@wolfv](https://github.com/wolfv))
+
+### Documentation improvements
+
+- FileType, Manager and Register [#20](https://github.com/QuantStack/jupyterlab-blockly/pull/20) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-blockly/graphs/contributors?from=2022-04-11&to=2022-06-15&type=c))
+
+[@DenisaCG](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-blockly+involves%3ADenisaCG+updated%3A2022-04-11..2022-06-15&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-blockly+involves%3Ahbcarlos+updated%3A2022-04-11..2022-06-15&type=Issues) | [@wolfv](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-blockly+involves%3Awolfv+updated%3A2022-04-11..2022-06-15&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a0
 
 ([Full Changelog](https://github.com/QuantStack/jupyterlab-blockly/compare/first-commit...7621d106ba51831512b803f07f1dd70b48b41a79))
@@ -29,5 +56,3 @@
 ([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-blockly/graphs/contributors?from=2022-01-10&to=2022-04-11&type=c))
 
 [@DenisaCG](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-blockly+involves%3ADenisaCG+updated%3A2022-01-10..2022-04-11&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-blockly+involves%3Ahbcarlos+updated%3A2022-01-10..2022-04-11&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a1 on main
```
Python version: 0.1.0a1
npm version: jupyterlab-blockly: 0.1.0-alpha.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | QuantStack/jupyterlab-blockly  |
| Branch  | main  |
| Version Spec | 0.1.0-alpha.1 |
| Since | v0.1.0a0 |