### PR TITLE
Use `pydata-sphinx-theme`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'pydata_sphinx_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 myst_parser==0.18.0
 jupyterlite-sphinx
 sphinx
+pydata-sphinx-theme


### PR DESCRIPTION
Use the `pydata-sphinx-theme` theme for the docs, since many other projects have now adopted it as well.