### PR TITLE
Add JupyterLite badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # jupyterlab_blockly
 
-[![Github Actions Status](https://github.com/QuantStack/jupyterlab-blockly/actions/workflows/build.yml/badge.svg)](https://github.com/quantstack/jupyterlab-blockly/actions/workflows/build.yml)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/quantstack/jupyterlab-blockly/main?urlpath=lab)
+[![Github Actions Status](https://github.com/QuantStack/jupyterlab-blockly/actions/workflows/build.yml/badge.svg)](https://github.com/quantstack/jupyterlab-blockly/actions/workflows/build.yml)
+[![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge-launch.svg)](https://jupyterlab-blockly.readthedocs.io/en/latest/lite/lab/index.html?path=example.jpblockly)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/quantstack/jupyterlab-blockly/main?urlpath=lab)
+
 
 Blockly extension for JupyterLab.
 


### PR DESCRIPTION
So folks can try the extension with one-click in their browser: 

![image](https://user-images.githubusercontent.com/591645/179559079-97f1e7a8-073b-4485-b7ad-7723c2f60339.png)
