### PR TITLE
Fix Binder configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,7 +12,6 @@ jupyterlab_blockly
 docs
 examples
 node_modules
-patches
 scripts
 .eslintignore
 .eslintrc.js

--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -21,7 +21,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}?urlpath=lab) :point_left: Launch a Binder on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_`
+              body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}?urlpath=lab/tree/examples/example.jpblockly) :point_left: Launch a Binder on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_`
             })
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,6 @@
 **/package.json
 !/package.json
 **/tsconfig.json
-**/patches
 **/scripts
 **/*.d.ts
 
@@ -15,7 +14,6 @@ jupyterlab_blockly
 docs
 examples
 node_modules
-patches
 scripts
 .eslintignore
 .eslintrc.js

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, quantstack
+Copyright (c) 2024, QuantStack
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Github Actions Status](https://github.com/QuantStack/jupyterlab-blockly/actions/workflows/build.yml/badge.svg)](https://github.com/quantstack/jupyterlab-blockly/actions/workflows/build.yml)
 [![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge-launch.svg)](https://jupyterlab-blockly.readthedocs.io/en/latest/lite/lab/index.html?path=example.jpblockly)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/quantstack/jupyterlab-blockly/main?urlpath=lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/quantstack/jupyterlab-blockly/main?urlpath=lab/tree/examples/example.jpblockly)
 
 
 Blockly extension for JupyterLab.

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -19,4 +19,3 @@ dependencies:
   - wheel
   # additional packages for demos
   - ipywidgets >=8.1.3
-  - cookiecutter

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -11,7 +11,7 @@ channels:
 
 dependencies:
   # runtime dependencies
-  - python >=3.8,<3.12.0a0
+  - python >=3.10,<3.11.0a0
   - jupyterlab >=4.0.0,<5.0.0a0
   # labextension build dependencies
   - nodejs >=18,<19

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -22,3 +22,4 @@ dependencies:
   - async_generator
   # additional packages for demos
   - ipywidgets
+  - jupyterlab-language-pack-fr-FR

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -18,4 +18,4 @@ dependencies:
   - pip
   - wheel
   # additional packages for demos
-  - ipywidgets
+  # - ipywidgets

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,5 +17,7 @@ dependencies:
   - nodejs >=18,<19
   - pip
   - wheel
+  - certipy
+  - async_generator
   # additional packages for demos
-  - ipywidgets >=8.1.3
+  - ipywidgets

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -18,4 +18,5 @@ dependencies:
   - pip
   - wheel
   # additional packages for demos
-  # - ipywidgets
+  - ipywidgets >=8.1.3
+  - cookiecutter

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - nodejs >=18,<19
   - pip
   - wheel
+  # packages needed for build to succeed
   - certipy
   - async_generator
   # additional packages for demos

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -32,7 +32,7 @@ _(sys.executable, "-m", "pip", "check")
 # install the labextension
 _("jlpm", "install")
 _("jlpm", "build")
-_(sys.executable, "-m", "pip", "install", "-e", ".")
+_(sys.executable, "-m", "pip", "install", "-e", ".[dev]")
 _(sys.executable, "-m", "jupyter", "labextension", "develop", "--overwrite", ".")
 
 # verify the environment the extension didn't break anything

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -30,6 +30,8 @@ def _(*args, **kwargs):
 _(sys.executable, "-m", "pip", "check")
 
 # install the labextension
+_("jlpm", "install")
+_("jlpm", "build")
 _(sys.executable, "-m", "pip", "install", "-e", ".")
 _(sys.executable, "-m", "jupyter", "labextension", "develop", "--overwrite", ".")
 

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "prettier": "jlpm prettier:base --write --list-different",
     "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css}\"",
     "prettier:check": "jlpm prettier:base --check",
-    "watch": "lerna run --stream watch",
-    "postinstall": "patch-package"
+    "watch": "lerna run --stream watch"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.1",
@@ -51,7 +50,6 @@
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.30.0",
-    "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.5.1",
     "typescript": "~5.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "jupyterlab_widgets~=1.1"
+    "jupyterlab_widgets"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "jupyterlab_widgets"
+    "jupyterlab_widgets~=3.0.11"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3477,7 +3477,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.1":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -4914,15 +4914,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-yarn-workspace-root@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "find-yarn-workspace-root@npm:2.0.0"
-  dependencies:
-    micromatch: ^4.0.2
-  checksum: fa5ca8f9d08fe7a54ce7c0a5931ff9b7e36f9ee7b9475fb13752bcea80ec6b5f180fa5102d60b376d5526ce924ea3fc6b19301262efa0a5d248dd710f3644242
-  languageName: node
-  linkType: hard
-
 "flat-cache@npm:^3.0.4":
   version: 3.0.4
   resolution: "flat-cache@npm:3.0.4"
@@ -5003,7 +4994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:9.1.0, fs-extra@npm:^9.0.0, fs-extra@npm:^9.1.0":
+"fs-extra@npm:9.1.0, fs-extra@npm:^9.1.0":
   version: 9.1.0
   resolution: "fs-extra@npm:9.1.0"
   dependencies:
@@ -5865,7 +5856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-ci@npm:2.0.0, is-ci@npm:^2.0.0":
+"is-ci@npm:2.0.0":
   version: 2.0.0
   resolution: "is-ci@npm:2.0.0"
   dependencies:
@@ -6114,7 +6105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-wsl@npm:^2.1.1, is-wsl@npm:^2.2.0":
+"is-wsl@npm:^2.2.0":
   version: 2.2.0
   resolution: "is-wsl@npm:2.2.0"
   dependencies:
@@ -6440,7 +6431,6 @@ __metadata:
     eslint-plugin-prettier: ^4.0.0
     eslint-plugin-react: ^7.30.0
     lerna: ^6.5.1
-    patch-package: ^6.4.7
     postinstall-postinstall: ^2.1.0
     prettier: ^2.5.1
     typescript: ~5.0.2
@@ -6492,15 +6482,6 @@ __metadata:
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
   checksum: 3ab01e7b1d440b22fe4c31f23d8d38b4d9b91d9f291df683476576493d5dfd2e03848a8b05813dd0c3f0e835bc63f433007ddeceb71f05cb25c45ae1b19c6d3b
-  languageName: node
-  linkType: hard
-
-"klaw-sync@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "klaw-sync@npm:6.0.0"
-  dependencies:
-    graceful-fs: ^4.1.11
-  checksum: 0da397f8961313c3ef8f79fb63af9002cde5a8fb2aeb1a37351feff0dd6006129c790400c3f5c3b4e757bedcabb13d21ec0a5eaef5a593d59515d4f2c291e475
   languageName: node
   linkType: hard
 
@@ -6957,7 +6938,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4":
+"micromatch@npm:^4.0.4":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:
@@ -7856,16 +7837,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^7.4.2":
-  version: 7.4.2
-  resolution: "open@npm:7.4.2"
-  dependencies:
-    is-docker: ^2.0.0
-    is-wsl: ^2.1.1
-  checksum: 3333900ec0e420d64c23b831bc3467e57031461d843c801f569b2204a1acc3cd7b3ec3c7897afc9dde86491dfa289708eb92bba164093d8bd88fb2c231843c91
-  languageName: node
-  linkType: hard
-
 "open@npm:^8.4.0":
   version: 8.4.2
   resolution: "open@npm:8.4.2"
@@ -8190,30 +8161,6 @@ __metadata:
   dependencies:
     entities: ^4.4.0
   checksum: 59465dd05eb4c5ec87b76173d1c596e152a10e290b7abcda1aecf0f33be49646ea74840c69af975d7887543ea45564801736356c568d6b5e71792fd0f4055713
-  languageName: node
-  linkType: hard
-
-"patch-package@npm:^6.4.7":
-  version: 6.5.1
-  resolution: "patch-package@npm:6.5.1"
-  dependencies:
-    "@yarnpkg/lockfile": ^1.1.0
-    chalk: ^4.1.2
-    cross-spawn: ^6.0.5
-    find-yarn-workspace-root: ^2.0.0
-    fs-extra: ^9.0.0
-    is-ci: ^2.0.0
-    klaw-sync: ^6.0.0
-    minimist: ^1.2.6
-    open: ^7.4.2
-    rimraf: ^2.6.3
-    semver: ^5.6.0
-    slash: ^2.0.0
-    tmp: ^0.0.33
-    yaml: ^1.10.2
-  bin:
-    patch-package: index.js
-  checksum: 8530ffa30f11136b527c6eddf6da48fa12856ee510a47edb1f9cdf8a025636adb82968f5fae778b5e04ce8c87915ebdf5911422b54add59a5a42e372a8f30eb2
   languageName: node
   linkType: hard
 
@@ -8992,17 +8939,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^2.6.3":
-  version: 2.7.1
-  resolution: "rimraf@npm:2.7.1"
-  dependencies:
-    glob: ^7.1.3
-  bin:
-    rimraf: ./bin.js
-  checksum: cdc7f6eacb17927f2a075117a823e1c5951792c6498ebcce81ca8203454a811d4cf8900314154d3259bb8f0b42ab17f67396a8694a54cae3283326e57ad250cd
-  languageName: node
-  linkType: hard
-
 "rimraf@npm:^3.0.0, rimraf@npm:^3.0.2":
   version: 3.0.2
   resolution: "rimraf@npm:3.0.2"
@@ -9322,13 +9258,6 @@ __metadata:
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
   checksum: 94a93fff615f25a999ad4b83c9d5e257a7280c90a32a7cb8b4a87996e4babf322e469c42b7f649fd5796edd8687652f3fb452a86dc97a816f01113183393f11c
-  languageName: node
-  linkType: hard
-
-"slash@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "slash@npm:2.0.0"
-  checksum: 512d4350735375bd11647233cb0e2f93beca6f53441015eea241fe784d8068281c3987fbaa93e7ef1c38df68d9c60013045c92837423c69115297d6169aa85e6
   languageName: node
   linkType: hard
 
@@ -10897,7 +10826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^1.10.0, yaml@npm:^1.10.2":
+"yaml@npm:^1.10.0":
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f


### PR DESCRIPTION
Fix Binder configuration and remove patches mention, as it's not needed after the `v4` migration. Also upgrade pinned version of `jupyterlab_widgets` package.