### PR TITLE
Restore `bump-version` script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,6 @@ before-bump-version = [
     "jlpm"
 ]
 before-build-npm = [
-    "python -m pip install 'jupyterlab>=4.0.0,<5'",
-    "jlpm",
     "jlpm build:prod"
 ]
 before-build-python = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,12 @@ version_cmd = "python scripts/bump-version.py --force"
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = [
-    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "python -m pip install -U jupyterlab"
     "jlpm"
 ]
 before-build-npm = [
+    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "jlpm"
     "jlpm build:prod"
 ]
 before-build-python = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,13 +75,11 @@ version_cmd = "python scripts/bump-version.py --force"
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = [
-    "python -m pip install -U jupyterlab"
+    "python -m pip install 'jupyterlab>=4.0.0,<5'",
     "jlpm"
 ]
 before-build-npm = [
-    "python -m pip install 'jupyterlab>=4.0.0,<5'",
-    "jlpm"
-    "jlpm build:prod"
+    "YARN_ENABLE_IMMUTABLE_INSTALLS=0 jlpm build:prod"
 ]
 before-build-python = [
     # Build the assets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,13 @@ source_dir = "src"
 build_dir = "jupyterlab_blockly/labextension"
 
 [tool.jupyter-releaser.options]
-version_cmd = "hatch version"
+version_cmd = "python scripts/bump-version.py --force"
 
 [tool.jupyter-releaser.hooks]
+before-bump-version = [
+    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "jlpm"
+]
 before-build-npm = [
     "python -m pip install 'jupyterlab>=4.0.0,<5'",
     "jlpm",

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,0 +1,76 @@
+#############################################################################
+# Copyright (c) 2018, Voila Contributors                                    #
+# Copyright (c) 2024, QuantStack                                            #
+#                                                                           #
+# Distributed under the terms of the BSD 3-Clause License.                  #
+#                                                                           #
+# The full license is in the file LICENSE, distributed with this software.  #
+#############################################################################
+
+import json
+from pathlib import Path
+
+import click
+from jupyter_releaser.util import get_version, run
+from pkg_resources import parse_version
+
+LERNA_CMD = "jlpm lerna version --no-push --force-publish --no-git-tag-version"
+
+
+@click.command()
+@click.option("--force", default=False, is_flag=True)
+@click.argument("spec", nargs=1)
+def bump(force, spec):
+    status = run("git status --porcelain").strip()
+    if len(status) > 0:
+        raise Exception("Must be in a clean git state with no untracked files")
+
+    curr = parse_version(get_version())
+    if spec == 'next':
+        spec = f"{curr.major}.{curr.minor}."
+        if curr.pre:
+            p, x = curr.pre
+            spec += f"{curr.micro}{p}{x + 1}"
+        else:
+            spec += f"{curr.micro + 1}"
+
+    elif spec == 'patch':
+        spec = f"{curr.major}.{curr.minor}."
+        if curr.pre:
+            spec += f"{curr.micro}"
+        else:
+            spec += f"{curr.micro + 1}"
+
+
+    version = parse_version(spec)
+
+    # convert the Python version
+    js_version = f"{version.major}.{version.minor}.{version.micro}"
+    if version.pre:
+        p, x = version.pre
+        p = p.replace("a", "alpha").replace("b", "beta")
+        js_version += f"-{p}.{x}"
+
+    # bump the JS packages
+    lerna_cmd = f"{LERNA_CMD} {js_version}"
+    if force:
+        lerna_cmd += " --yes"
+    run(lerna_cmd)
+
+    HERE = Path(__file__).parent.parent.resolve()
+    path = HERE.joinpath("package.json")
+    if path.exists():
+        with path.open(mode="r") as f:
+            data = json.load(f)
+
+        data["version"] = js_version
+
+        with path.open(mode="w") as f:
+            json.dump(data, f, indent=2)
+
+    else:
+        raise FileNotFoundError(f"Could not find package.json under dir {path!s}")
+
+
+if __name__ == "__main__":
+    bump()

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,5 +1,5 @@
 #############################################################################
-# Copyright (c) 2018, Voila Contributors                                    #
+# Copyright (c) 2024, Voila Contributors                                    #
 # Copyright (c) 2024, QuantStack                                            #
 #                                                                           #
 # Distributed under the terms of the BSD 3-Clause License.                  #


### PR DESCRIPTION
Restore `bump-version.py` script that bumps the lerna version of the extension, as well as the versions specified inside the individual `package.json` files in `blockly` and `blockly-extension`, as well as update `pyproject.toml` with the associated commands of successfully running the script.