### PR TITLE
Update Lite deployment 

### DIFF
--- a/docs/build-environment.yml
+++ b/docs/build-environment.yml
@@ -8,8 +8,8 @@ dependencies:
   - myst-parser
   - pydata-sphinx-theme
   - python
-  - jupyterlab-blockly
   - pip:
+    - jupyterlab-blockly
     - jupyterlite-core
     - jupyterlite-sphinx
     - jupyterlite-xeus

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2024, QuantStack'
 author = 'Denisa Checiu'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.1'
+release = '0.3.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2024, QuantStack'
 author = 'Denisa Checiu'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.0'
+release = '0.3.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/other_extensions.md
+++ b/docs/other_extensions.md
@@ -120,7 +120,7 @@ You will need to request the `jupyterlab-blockly` package as a dependency of you
 
 setup_args = dict(
   ...
-  install_requires=['jupyterlab-blockly>=0.3.1,<0.4']
+  install_requires=['jupyterlab-blockly>=0.3.2,<0.4']
   ...
 )
 ```

--- a/docs/other_extensions.md
+++ b/docs/other_extensions.md
@@ -120,7 +120,7 @@ You will need to request the `jupyterlab-blockly` package as a dependency of you
 
 setup_args = dict(
   ...
-  install_requires=['jupyterlab-blockly>=0.3.0,<0.4']
+  install_requires=['jupyterlab-blockly>=0.3.1,<0.4']
   ...
 )
 ```


### PR DESCRIPTION
Update the `build-environment.yml` script to install  the `jupyterlab-blockly` extension with `pip` instead of `conda`.