### PR TITLE
Fix `Blockly` language for default locale

### DIFF
--- a/packages/blockly-extension/src/index.ts
+++ b/packages/blockly-extension/src/index.ts
@@ -168,8 +168,10 @@ const plugin: JupyterFrontEndPlugin<IBlocklyRegistry> = {
       // Get new language and call the function that modifies the language name accordingly.
       // Also, make the transformation to have the name of the language package as in Blockly.
       const language =
-        currentLocale[currentLocale.length - 2].toUpperCase() +
-        currentLocale[currentLocale.length - 1].toLowerCase();
+        currentLocale === 'default'
+          ? 'En'
+          : currentLocale[currentLocale.length - 2].toUpperCase() +
+            currentLocale[currentLocale.length - 1].toLowerCase();
       console.log(`Current Language : '${language}'`);
 
       // Transmitting the current language to the manager.


### PR DESCRIPTION
In the `Settings Editor` in `JupyterLab` the locale settings (language) get initialized with `default` instead of `En`, representing English. This PR updates the logic such that it deals with the `default` case by loading the English message pack for `Blockly`.