### PR TITLE
Update docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,12 @@ To install the extension, execute:
 conda install -c conda-forge jupyterlab-blockly
 ```
 
+or
+
+```bash
+pip install jupyterlab-blockly
+```
+
 ### Kernels
 
 - ipykernel
@@ -28,6 +34,12 @@ To remove the extension, execute:
 conda uninstall -c conda-forge jupyterlab-blockly
 ```
 
+or 
+
+```bash
+pip uninstall jupyterlab-blockly
+```
+
 ## Development install
 
 **Note:** You will need NodeJS to build the extension package.
@@ -37,7 +49,7 @@ The `jlpm` command is JupyterLab's pinned version of
 `yarn` or `npm` in lieu of `jlpm` below.
 
 ```bash
-micromamba create -n blockly -c conda-forge python nodejs=18 yarn pre-commit jupyterla jupyter-packaging jupyterlab-language-pack-es-ES jupyterlab-language-pack-fr-FR ipykernel xeus-python xeus-lua
+micromamba create -n blockly -c conda-forge python nodejs=18 yarn pre-commit jupyterla jupyterlab-language-pack-es-ES jupyterlab-language-pack-fr-FR ipykernel xeus-python xeus-lua
 micromamba activate blockly
 # Clone the repo to your local environment
 # Change directory to the jupyterlab_blockly directory

--- a/docs/other_extensions.md
+++ b/docs/other_extensions.md
@@ -115,7 +115,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
 You will need to request the `jupyterlab-blockly` package as a dependency for your extension, in order to ensure it is installed and available to provide the token `IBlocklyRegistry`. To do this, you need to add the following line to your `pyproject.toml` file.
 
-```toml
+```
 // pyproject.toml : 26
 
 dependencies = [

--- a/docs/other_extensions.md
+++ b/docs/other_extensions.md
@@ -124,9 +124,7 @@ dependencies = [
 ]
 ```
 
-Additionally, you will need to add the webpack configuration for loading the `Blockly` source maps.
-
-You can do this, by creating the following `webpack.config.js` file inside your root directory:
+Additionally, you will need to add the webpack configuration for loading the `Blockly` source maps. You can do this, by creating the following `webpack.config.js` file inside your root directory:
 
 ```js
 // @ts-check

--- a/docs/other_extensions.md
+++ b/docs/other_extensions.md
@@ -146,7 +146,7 @@ module.exports = /** @type { import('webpack').Configuration } */ ({
 });
 ```
 
-and by connecting the `webpack` config to your `jupyterlab` intstance, by adding the following line inside your `package.json`: 
+and by connecting the `webpack` config to your `jupyterlab` instance, which entails adding the following line inside your `package.json`: 
 
 ```json
 "jupyterlab": {

--- a/docs/other_extensions.md
+++ b/docs/other_extensions.md
@@ -8,6 +8,7 @@ You can easily create a new JupyterLab extension by using the official `copier` 
 After installing the needed plugins (mentioned in the above link) and creating an extension directory, you can run the following command:
 ```
 copier copy --trust https://github.com/jupyterlab/extension-template .
+```
 which will ask you to fill some basic information about your project. Once completed, the directory will be populated with several files, all forming the base of your project. You will mostly work in the `index.ts` file, located in the `src` folder.
 
 An example of creating a simple JupyterLab extension, which also contains the instructions of how to fill the information asked by the `copier` template, can be found [here](https://github.com/jupyterlab/extension-examples/tree/master/hello-world).


### PR DESCRIPTION
Update documentation to include the relevant information about creating another extension on top of `jupyterlab-blockly`, in line with the new updates made by migrating to `v4` of `JupyterLab`.