### PR TITLE
Store selected kernel and toolbox in .jpblockly file

### DIFF
--- a/packages/blockly/src/manager.ts
+++ b/packages/blockly/src/manager.ts
@@ -169,36 +169,42 @@ export class BlocklyManager {
   private _filterContents(contents: ToolboxItemInfo[]): number {
     let visible = 0;
     contents.forEach(itemInfo => {
-      if ("kind" in itemInfo) {
-        if (itemInfo.kind.toUpperCase() === "CATEGORY") {
-          if ("contents" in itemInfo) {
+      if ('kind' in itemInfo) {
+        if (itemInfo.kind.toUpperCase() === 'CATEGORY') {
+          if ('contents' in itemInfo) {
             const categoryInfo = itemInfo as StaticCategoryInfo;
             if (this._filterContents(categoryInfo.contents) > 0) {
               visible++;
-              categoryInfo.hidden = "false";
+              categoryInfo.hidden = 'false';
             } else {
-              categoryInfo.hidden = "true";
+              categoryInfo.hidden = 'true';
             }
-          } else if ("custom" in itemInfo) {
+          } else if ('custom' in itemInfo) {
             const categoryInfo = itemInfo as DynamicCategoryInfo;
-            if (this._allowedBlocks === undefined || this._allowedBlocks.includes(categoryInfo.custom.toLowerCase())) {
-              categoryInfo.hidden = "false";
+            if (
+              this._allowedBlocks === undefined ||
+              this._allowedBlocks.includes(categoryInfo.custom.toLowerCase())
+            ) {
+              categoryInfo.hidden = 'false';
               visible++;
-              console.log("Category " + categoryInfo.custom + " is allowed");
+              console.log(`Category ${categoryInfo.custom} is allowed`);
             } else {
-              categoryInfo.hidden = "true";
-              console.log("Category " + categoryInfo.custom + " is not allowed");
+              categoryInfo.hidden = 'true';
+              console.log(`Category ${categoryInfo.custom} is not allowed`);
             }
           }
-        } else if (itemInfo.kind.toUpperCase() === "BLOCK") {
+        } else if (itemInfo.kind.toUpperCase() === 'BLOCK') {
           const blockInfo = itemInfo as BlockInfo;
-          if (this._allowedBlocks === undefined || this._allowedBlocks.includes(blockInfo.type.toLowerCase())) {
+          if (
+            this._allowedBlocks === undefined ||
+            this._allowedBlocks.includes(blockInfo.type.toLowerCase())
+          ) {
             blockInfo.disabled = false;
             blockInfo.disabledReasons = [];
             visible++;
           } else {
             blockInfo.disabled = true;
-            blockInfo.disabledReasons = ["This block is not allowed"];
+            blockInfo.disabledReasons = ['This block is not allowed'];
           }
         }
       }

--- a/packages/blockly/src/manager.ts
+++ b/packages/blockly/src/manager.ts
@@ -8,7 +8,14 @@ import { ISignal, Signal } from '@lumino/signaling';
 import * as Blockly from 'blockly';
 
 import { BlocklyRegistry } from './registry';
-import { ToolboxDefinition } from 'blockly/core/utils/toolbox';
+import {
+  BlockInfo,
+  DynamicCategoryInfo,
+  StaticCategoryInfo,
+  ToolboxDefinition,
+  ToolboxInfo,
+  ToolboxItemInfo
+} from 'blockly/core/utils/toolbox';
 
 /**
  * BlocklyManager the manager for each document
@@ -17,6 +24,7 @@ import { ToolboxDefinition } from 'blockly/core/utils/toolbox';
  */
 export class BlocklyManager {
   private _toolbox: string;
+  private _allowedBlocks: string[];
   private _generator: Blockly.Generator;
   private _registry: BlocklyRegistry;
   private _selectedKernel: KernelSpec.ISpecModel;
@@ -37,6 +45,7 @@ export class BlocklyManager {
     this._mimetypeService = mimetypeService;
 
     this._toolbox = 'default';
+    this._filterToolbox();
     this._generator = this._registry.generators.get('python');
 
     this._changed = new Signal<this, BlocklyManager.Change>(this);
@@ -112,6 +121,7 @@ export class BlocklyManager {
     if (this._toolbox !== name) {
       const toolbox = this._registry.toolboxes.get(name);
       this._toolbox = toolbox ? name : 'default';
+      this._filterToolbox();
       this._changed.emit('toolbox');
     }
   }
@@ -127,6 +137,73 @@ export class BlocklyManager {
       list.push({ label: name, value: name });
     });
     return list;
+  }
+
+  /**
+   * Get the list of allowed blocks. If undefined, all blocks are allowed.
+   *
+   * @returns The list of allowed blocks.
+   */
+  getAllowedBlocks() {
+    return this._allowedBlocks;
+  }
+
+  /**
+   * Set the list of allowed blocks. If undefined, all blocks are allowed.
+   *
+   * @param allowedBlocks The list of allowed blocks.
+   */
+  setAllowedBlocks(allowedBlocks: string[]) {
+    this._allowedBlocks = allowedBlocks;
+    this._filterToolbox();
+    this._changed.emit('toolbox');
+  }
+
+  private _filterToolbox() {
+    const toolbox = this._registry.toolboxes.get(this._toolbox) as ToolboxInfo;
+    if (toolbox) {
+      this._filterContents(toolbox.contents);
+    }
+  }
+
+  private _filterContents(contents: ToolboxItemInfo[]): number {
+    let visible = 0;
+    contents.forEach(itemInfo => {
+      if ("kind" in itemInfo) {
+        if (itemInfo.kind.toUpperCase() === "CATEGORY") {
+          if ("contents" in itemInfo) {
+            const categoryInfo = itemInfo as StaticCategoryInfo;
+            if (this._filterContents(categoryInfo.contents) > 0) {
+              visible++;
+              categoryInfo.hidden = "false";
+            } else {
+              categoryInfo.hidden = "true";
+            }
+          } else if ("custom" in itemInfo) {
+            const categoryInfo = itemInfo as DynamicCategoryInfo;
+            if (this._allowedBlocks === undefined || this._allowedBlocks.includes(categoryInfo.custom.toLowerCase())) {
+              categoryInfo.hidden = "false";
+              visible++;
+              console.log("Category " + categoryInfo.custom + " is allowed");
+            } else {
+              categoryInfo.hidden = "true";
+              console.log("Category " + categoryInfo.custom + " is not allowed");
+            }
+          }
+        } else if (itemInfo.kind.toUpperCase() === "BLOCK") {
+          const blockInfo = itemInfo as BlockInfo;
+          if (this._allowedBlocks === undefined || this._allowedBlocks.includes(blockInfo.type.toLowerCase())) {
+            blockInfo.disabled = false;
+            blockInfo.disabledReasons = [];
+            visible++;
+          } else {
+            blockInfo.disabled = true;
+            blockInfo.disabledReasons = ["This block is not allowed"];
+          }
+        }
+      }
+    });
+    return visible;
   }
 
   /**

--- a/packages/blockly/src/widget.ts
+++ b/packages/blockly/src/widget.ts
@@ -174,6 +174,9 @@ export class BlocklyPanel extends SplitPanel {
             console.warn(`Unknown kernel in blockly file: ` + kernel);
           }
         }
+        if (metadata['allowed_blocks']) {
+          this._manager.setAllowedBlocks(metadata['allowed_blocks']);
+        }
       }
     } else {
       // Unsupported format
@@ -194,6 +197,7 @@ export class BlocklyPanel extends SplitPanel {
         workspace: workspace as any,
         metadata: {
           toolbox: this._manager.getToolbox(),
+          allowed_blocks: this._manager.getAllowedBlocks(),
           kernel: this._manager.kernel
         }
       };

--- a/packages/blockly/src/widget.ts
+++ b/packages/blockly/src/widget.ts
@@ -5,9 +5,9 @@ import {
 } from '@jupyterlab/docregistry';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { runIcon } from '@jupyterlab/ui-components';
-import { showErrorMessage } from "@jupyterlab/apputils";
+import { showErrorMessage } from '@jupyterlab/apputils';
 
-import { PartialJSONObject } from "@lumino/coreutils";
+import { PartialJSONObject } from '@lumino/coreutils';
 import { SplitPanel } from '@lumino/widgets';
 import { Signal } from '@lumino/signaling';
 
@@ -148,30 +148,37 @@ export class BlocklyPanel extends SplitPanel {
     // Check if format is set or if we have legacy content
     if (fileFormat === undefined && fileContent['blocks']) {
       // Load legacy content
-      (this.layout as BlocklyLayout).workspace = fileContent as any as Blockly.Workspace;
+      (this.layout as BlocklyLayout).workspace =
+        fileContent as any as Blockly.Workspace;
     } else if (fileFormat === 2) {
       // Load the content from the "workspace" key
-      (this.layout as BlocklyLayout).workspace = fileContent['workspace'] as any as Blockly.Workspace;
+      const workspace = fileContent['workspace'] as any as Blockly.Workspace;
+      (this.layout as BlocklyLayout).workspace = workspace;
       const metadata = fileContent['metadata'];
       if (metadata) {
         if (metadata['toolbox']) {
           const toolbox = metadata['toolbox'];
-          if (this._manager.listToolboxes().find(value => value.value === toolbox)) {
+          if (
+            this._manager.listToolboxes().find(value => value.value === toolbox)
+          ) {
             this._manager.setToolbox(metadata['toolbox']);
           } else {
             // Unknown toolbox
-            showErrorMessage(`Unknown toolbox`,
-                `The toolbox '` + toolbox + `' is not available. Using default toolbox.`
+            showErrorMessage(
+              'Unknown toolbox',
+              `The toolbox '${toolbox}' is not available. Using default toolbox.`
             );
           }
         }
         if (metadata['kernel'] && metadata['kernel'] !== 'No kernel') {
           const kernel = metadata['kernel'];
-          if (this._manager.listKernels().find(value => value.value === kernel)) {
+          if (
+            this._manager.listKernels().find(value => value.value === kernel)
+          ) {
             this._manager.selectKernel(metadata['kernel']);
           } else {
             // Unknown kernel
-            console.warn(`Unknown kernel in blockly file: ` + kernel);
+            console.warn(`Unknown kernel in blockly file: ${kernel}`);
           }
         }
         if (metadata['allowed_blocks']) {
@@ -180,8 +187,9 @@ export class BlocklyPanel extends SplitPanel {
       }
     } else {
       // Unsupported format
-      showErrorMessage(`Unsupported file format`,
-          `The file format '` + fileFormat + `' is not supported by the Blockly editor.`
+      showErrorMessage(
+        'Unsupported file format',
+        `The file format '${fileFormat}' is not supported by the Blockly editor.`
       );
     }
   }


### PR DESCRIPTION
This adjusts the format of the .jpblockly files to allow storing of additional metadata similarly to .ipynb files: It stores the selected kernel and toolbox as well as adds the ability to define a list of allowed blocks.

While improving the experience when using the Blockly editor (as one doesn't need to select the kernel and toolbox manually on each file open) this also makes it possible to distribute pre-configured files for certain types of content e.g. for exercises that should be done only with certain blocks.

Old file in the previous format are loaded and automatically stored in the new one on the next save.